### PR TITLE
issue #4 bugfix

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -316,8 +316,9 @@ Parse.prototype._flush = function (callback) {
     return setImmediate(this._flush.bind(this, callback));
   }
 
+  var r = callback();
   this.emit('close');
-  return callback();
+  return r;
 };
 
 Parse.prototype.addListener = function(type, listener) {


### PR DESCRIPTION
Parser's flush callback was called after emitting 'close'-event.
