### PR TITLE
Added ability to override zlib default options

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -136,7 +136,7 @@ Parse.prototype._readFile = function () {
           var inflater;
 
           if(has_compression) {
-            inflater = zlib.createInflateRaw();
+            inflater = zlib.createInflateRaw(self._opts.zlibOptions || {});
             inflater.on('error', function (err) {
               self.emit('error', err);
             });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -316,8 +316,9 @@ Parse.prototype._flush = function (callback) {
     return setImmediate(this._flush.bind(this, callback));
   }
 
+  var r = callback();
   this.emit('close');
-  return callback();
+  return r;
 };
 
 Parse.prototype.addListener = function(type, listener) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "fstream": "~0.1.21",
+    "fstream": "~1.0.8",
     "pullstream": "~0.4.0",
     "binary": "~0.3.0",
     "readable-stream": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzip2",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Unzip cross-platform streaming API compatible with fstream and fs.ReadStream",
   "author": "Hlib Dmytriiev <glebdmitriew@gmail.com>",
   "maintainers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "unzip",
-  "version": "0.2.2",
+  "name": "unzip2",
+  "version": "0.2.6",
   "description": "Unzip cross-platform streaming API compatible with fstream and fs.ReadStream",
   "author": "Hlib Dmytriiev <glebdmitriew@gmail.com>",
   "maintainers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzip",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Unzip cross-platform streaming API compatible with fstream and fs.ReadStream",
   "author": "Hlib Dmytriiev <glebdmitriew@gmail.com>",
   "maintainers": [


### PR DESCRIPTION
I added ability to override zlib default options with zlibOptions -parameter.

Example:

```
unzip.Parse({ zlibOptions : {
            flush: zlib.Z_FULL_FLUSH
}}
```

https://nodejs.org/api/zlib.html#zlib_zlib_inflateraw_buf_options_callback

I had to set flush to zlib.Z_FULL_FLUSH because with default option my unzip script failed for some reason, so I decided to create this fork. Please free to merge this.
