### PR TITLE
fix unzip uncompressed blank files

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -149,7 +149,14 @@ Parse.prototype._readFile = function () {
               if(has_compression) {
                 self._pullStream.pipe(vars.compressedSize, inflater).pipe(entry);
               } else {
-                self._pullStream.pipe(vars.compressedSize, entry);
+                self._pullStream.pull(vars.compressedSize, function (err, compressedData) {
+                  if (err) {
+                    return self.emit('error', err);
+                  }
+
+                  entry.write(compressedData);
+                  entry.end();
+                });
               }
             } else {
               self._pullStream.drain(vars.compressedSize, function (err) {


### PR DESCRIPTION
any blank file inside archive breaks Parse method.
