### PR TITLE
Use most current version of fstream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "fstream": "~0.1.21",
+    "fstream": "~1.0.10",
     "pullstream": "~0.4.0",
     "binary": "~0.3.0",
     "readable-stream": "~1.0.0",


### PR DESCRIPTION
Use the most current version of the 'fstream' dependency, v1.0.10.

This version of fstream uses graceful-fs ^4.1.2 (instead of 3.0.8), which is compatible with Node 6.

Using graceful-fs 4 avoids the following notice in node 6: `(node:14615) fs: re-evaluating native module sources is not supported. If you are using the graceful-fs module, please update it to a more recent version.`
