### PR TITLE
Update fstream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "fstream": "~1.0.12",
-    "pullstream": "~0.4.0",
     "binary": "~0.3.0",
+    "fstream": "^1.0.12",
+    "match-stream": "~0.0.2",
+    "pullstream": "~0.4.0",
     "readable-stream": "~1.0.0",
-    "setimmediate": "~1.0.1",
-    "match-stream": "~0.0.2"
+    "setimmediate": "~1.0.1"
   },
   "devDependencies": {
     "tap": "~0.3.0",


### PR DESCRIPTION
Fixes: #13 

Fixes "ReferenceError: primordials is not defined"